### PR TITLE
box-sizing: border-box の場合、計算式を変更

### DIFF
--- a/dist/match-height.js
+++ b/dist/match-height.js
@@ -77,11 +77,17 @@
 	        const maxHeightInRow = Math.max(...processingTargets.map((item) => item.height));
 	        processingTargets.forEach((item) => {
 	            const error = processingTop - item.top + errorThreshold;
-	            const paddingAndBorder = parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-top')) +
-	                parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-bottom')) +
-	                parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-top-width')) +
-	                parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-bottom-width'));
-	            item.el.style.minHeight = `${maxHeightInRow - paddingAndBorder + error}px`;
+	            const isBorderBox = window.getComputedStyle(item.el).getPropertyValue('box-sizing') === 'border-box';
+	            if (isBorderBox) {
+	                item.el.style.minHeight = `${maxHeightInRow + error}px`;
+	            }
+	            else {
+	                const paddingAndBorder = parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-top')) +
+	                    parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-bottom')) +
+	                    parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-top-width')) +
+	                    parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-bottom-width'));
+	                item.el.style.minHeight = `${maxHeightInRow - paddingAndBorder + error}px`;
+	            }
 	        });
 	        this._remains.splice(0, processingTargets.length);
 	        if (0 < this._remains.length)

--- a/dist/match-height.module.js
+++ b/dist/match-height.module.js
@@ -71,11 +71,17 @@ class MatchHeight {
         const maxHeightInRow = Math.max(...processingTargets.map((item) => item.height));
         processingTargets.forEach((item) => {
             const error = processingTop - item.top + errorThreshold;
-            const paddingAndBorder = parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-top')) +
-                parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-bottom')) +
-                parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-top-width')) +
-                parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-bottom-width'));
-            item.el.style.minHeight = `${maxHeightInRow - paddingAndBorder + error}px`;
+            const isBorderBox = window.getComputedStyle(item.el).getPropertyValue('box-sizing') === 'border-box';
+            if (isBorderBox) {
+                item.el.style.minHeight = `${maxHeightInRow + error}px`;
+            }
+            else {
+                const paddingAndBorder = parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-top')) +
+                    parseFloat(window.getComputedStyle(item.el).getPropertyValue('padding-bottom')) +
+                    parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-top-width')) +
+                    parseFloat(window.getComputedStyle(item.el).getPropertyValue('border-bottom-width'));
+                item.el.style.minHeight = `${maxHeightInRow - paddingAndBorder + error}px`;
+            }
         });
         this._remains.splice(0, processingTargets.length);
         if (0 < this._remains.length)

--- a/src/match-height.ts
+++ b/src/match-height.ts
@@ -91,13 +91,18 @@ class MatchHeight {
 		processingTargets.forEach( ( item ) => {
 
 			const error = processingTop - item.top + errorThreshold;
-			const paddingAndBorder =
-				parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'padding-top' ) ) +
-				parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'padding-bottom' ) ) +
-				parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'border-top-width' ) ) +
-				parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'border-bottom-width' ) );
-			item.el.style.minHeight = `${ maxHeightInRow - paddingAndBorder + error }px`;
+			const isBorderBox = window.getComputedStyle( item.el ).getPropertyValue( 'box-sizing' ) === 'border-box';
 
+			if (isBorderBox) {
+				item.el.style.minHeight = `${ maxHeightInRow + error }px`;
+			} else {
+				const paddingAndBorder =
+					parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'padding-top' ) ) +
+					parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'padding-bottom' ) ) +
+					parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'border-top-width' ) ) +
+					parseFloat( window.getComputedStyle( item.el ).getPropertyValue( 'border-bottom-width' ) );
+				item.el.style.minHeight = `${ maxHeightInRow - paddingAndBorder + error }px`;
+			}
 		} );
 
 		this._remains.splice( 0, processingTargets.length );


### PR DESCRIPTION
対象の要素がbox-sizing: border-box の時に、getBoundingClientRect().height の値がpaddingとborderを含んでいるため、
``` item.el.style.minHeight = `${ maxHeightInRow - paddingAndBorder + error }px`; ``` の paddingAndBorder を引いた分ずれているようです。

変更点
計算前に isBorderBox を判断し、計算式に paddingAndBorder の減算を含めるかどうか分岐させています。

※あまりプルリクエストを作成することに慣れていないので、もしこの内容に失礼や改善点があればお気軽にお知らせください・・・！