### PR TITLE
Fix: Ensure getPropertyValue function returns style property value as a string

### DIFF
--- a/dist/match-height.js
+++ b/dist/match-height.js
@@ -77,7 +77,9 @@
 	        const maxHeightInRow = Math.max(...processingTargets.map((item) => item.height));
 	        processingTargets.forEach((item) => {
 	            const error = processingTop - item.top + errorThreshold;
-	            const getPropertyValue = window.getComputedStyle(item.el).getPropertyValue;
+	            const getPropertyValue = (value) => {
+	                return window.getComputedStyle(item.el).getPropertyValue(value);
+	            };
 	            const isBorderBox = getPropertyValue('box-sizing') === 'border-box';
 	            if (isBorderBox) {
 	                item.el.style.minHeight = `${maxHeightInRow + error}px`;

--- a/dist/match-height.module.js
+++ b/dist/match-height.module.js
@@ -71,7 +71,9 @@ class MatchHeight {
         const maxHeightInRow = Math.max(...processingTargets.map((item) => item.height));
         processingTargets.forEach((item) => {
             const error = processingTop - item.top + errorThreshold;
-            const getPropertyValue = window.getComputedStyle(item.el).getPropertyValue;
+            const getPropertyValue = (value) => {
+                return window.getComputedStyle(item.el).getPropertyValue(value);
+            };
             const isBorderBox = getPropertyValue('box-sizing') === 'border-box';
             if (isBorderBox) {
                 item.el.style.minHeight = `${maxHeightInRow + error}px`;

--- a/src/match-height.ts
+++ b/src/match-height.ts
@@ -91,7 +91,10 @@ class MatchHeight {
 		processingTargets.forEach( ( item ) => {
 
 			const error = processingTop - item.top + errorThreshold;
-			const getPropertyValue = window.getComputedStyle( item.el ).getPropertyValue;
+			const getPropertyValue = (value: string) => {
+				return window.getComputedStyle( item.el ).getPropertyValue(value)
+			}
+
 			const isBorderBox = getPropertyValue( 'box-sizing' ) === 'border-box';
 
 			if ( isBorderBox ) {


### PR DESCRIPTION
The getPropertyValue const was previously not returning any value, leading to a TypeScript error. 
getPropertyValue is now a function that returns the computed style property value as a string